### PR TITLE
🐛[Fix] 커밋 메시지 규칙 강제 과정에서의 예외 처리 및 규칙 수정 #3

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,10 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# 병합 커밋 메시지 검증 제외
+if grep -qE "^Merge branch" "$1"; then
+  exit 0
+fi
+
+# 커밋 메시지 검증 로직 추가
 node .husky/verifyCommitMessage.js "$@"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,10 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-# 병합 커밋 메시지 검증 제외
-if grep -qE "^Merge branch" "$1"; then
-  exit 0
-fi
-
-# 커밋 메시지 검증 로직 추가
 node .husky/verifyCommitMessage.js "$@"

--- a/.husky/verifyCommitMessage.js
+++ b/.husky/verifyCommitMessage.js
@@ -7,6 +7,11 @@ const commitMessageFilePath = process.argv[2];
 // 커밋 메시지를 읽어옵니다.
 const commitMessage = fs.readFileSync(commitMessageFilePath, "utf-8").trim();
 
+// 병합 커밋 메시지 검증 제외
+if (commitMessage.startsWith("Merge branch")) {
+  process.exit(0); // 병합 커밋 메시지는 검증을 건너뜁니다.
+}
+
 // 이모지를 무시하고 나머지 내용을 검증하기 위한 정규 표현식
 const commitMessagePattern = /^\[([A-Za-z ]+)\] .{1,50} #\d+$/;
 
@@ -15,7 +20,7 @@ const sanitizedCommitMessage = commitMessage.replace(/^[^\[]*/, "").trim(); // �
 
 // 커밋 메시지 형식을 검증합니다.
 if (!commitMessagePattern.test(sanitizedCommitMessage)) {
-    console.error(`
+  console.error(`
   사용가능한 commit의 형식은 아래와 같습니다.
   
   ===================== [태그이름] + 설명 + #이슈번호 =====================
@@ -38,7 +43,7 @@ if (!commitMessagePattern.test(sanitizedCommitMessage)) {
   ==================================================================
   형식에 맞춰 커밋 메시지를 다시 작성해주세요. 커밋 메시지는 설명 뒤에 이슈 번호도 포함해야 합니다. 예시: [Feat] 기능 추가 설명 #123
   `);
-    process.exit(1); // 검증 실패 시 프로세스를 종료합니다.
+  process.exit(1); // 검증 실패 시 프로세스를 종료합니다.
 }
 
 // 성공적으로 완료되면 프로세스를 종료합니다.

--- a/.husky/verifyCommitMessage.js
+++ b/.husky/verifyCommitMessage.js
@@ -13,7 +13,7 @@ if (commitMessage.startsWith("Merge branch")) {
 }
 
 // 이모지를 무시하고 나머지 내용을 검증하기 위한 정규 표현식
-const commitMessagePattern = /^\[([A-Za-z ]+)\] .{1,50} #\d+$/;
+const commitMessagePattern = /^\[([A-Za-z ]+)\] .{1,80} #\d+$/;
 
 // 이모지 제거: 이모지가 있다면 제거하고, 나머지 텍스트만 검증
 const sanitizedCommitMessage = commitMessage.replace(/^[^\[]*/, "").trim(); // 이모지 부분을 제거


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->

## 작업사항

<!-- 작업한 내용 작성 -->

- master 브랜치 pull 과정에서 자동 생성되는 커밋 메시지가 Husky에 의해 막히는 것을 확인
- 브랜치의 코드 변경 과정을 추적하기에 해당 자동 생성 메시지가 유용할 것으로 판단, 예외 처리
- 이 과정에서 이전에 설정된 커밋 메시지 50자 길이 제한이 너무 짧은 것으로 판단, 80자로 확장

## 미리보기, 사용방법 및 결과물
<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
```js
// 병합 커밋 메시지 검증 제외
if (commitMessage.startsWith("Merge branch")) {
  process.exit(0); // 병합 커밋 메시지는 검증을 건너뜁니다.
}
```
- 위 코드를 통해 커밋 메시지 시작이 "Merge branch"인 경우 검증에서 제외
```
// 이모지를 무시하고 나머지 내용을 검증하기 위한 정규 표현식
const commitMessagePattern = /^\[([A-Za-z ]+)\] .{1,80} #\d+$/;
```
- 기존 50자 제한에서 80자로 설정 변경, 더 자세한 작업 내용 작성이 가능
## 기타
<!-- 필요한 경우 작성 -->
 - 작업 과정 중, 더 이상 허스키의 v7 이상부터 훅 사용 방식이 바뀌어, pre-commit 파일 안에 작성한 코드가 작동하지 않는 것을 확인
 - 이후 수정할 일이 추가로 있다면 유의할 것.

## 작성일

<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->

2024.10.11
