### PR TITLE
✨[Feat] block layout 물음표 아이콘을 컴포넌트로 분리 #110

### DIFF
--- a/src/app/admin/block/components/question-icon.tsx
+++ b/src/app/admin/block/components/question-icon.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import Image from "next/image";
+
+interface Props {
+  title: string;
+}
+const QuestionIcon = ({ title }: Props) => {
+  if (title !== "링크 블록") return;
+  return (
+    <div className="group relative inline-block">
+      <Image
+        src="/assets/icons/icon_help.png"
+        alt="question"
+        width={30}
+        height={30}
+      />
+      <div className="absolute left-2 top-20 w-max -translate-x-1/2 -translate-y-1/2 transform rounded bg-[#343434] px-3 py-3 text-sm text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+        • 기본 정보와 공개 여부 값은 필수입니다. <br />• 예약 공개와 스티커는
+        프로 기능입니다.
+        <div className="absolute -top-3 left-1/2 h-0 w-0 rotate-90 border-y-8 border-r-8 border-y-transparent border-r-[#343434]"></div>
+      </div>
+    </div>
+  );
+};
+
+export default QuestionIcon;


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->

## 작업사항

<!-- 작업한 내용 작성 -->

- block layout 물음표 아이콘을 컴포넌트로 분리 

## 미리보기, 사용방법 및 결과물

<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
![스크린샷 2024-10-22 오후 5 06 23](https://github.com/user-attachments/assets/b6a82a25-c5f7-4f09-a377-bef3421789eb)


## 기타
위 사진에 있는 영역에 대한 부분을 관심사 분리하기 위해 코드 분리하였습니다

<!-- 필요한 경우 작성 -->

## 작성일

<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->

2024.10.22
