### PR TITLE
✨[Feat] 사용자 일정 리스트뷰 및 캘린더뷰 표시 기능 추가 #101

### DIFF
--- a/src/app/admin/(block)/calendar/components/calendar-view.tsx
+++ b/src/app/admin/(block)/calendar/components/calendar-view.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
-import { EventContentArg } from "@fullcalendar/core/index.js";
+import { EventContentArg, EventClickArg } from "@fullcalendar/core";
 import { Schedule } from "./types";
 
 interface CalendarViewProps {
@@ -51,7 +51,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
     return eventColors[index % eventColors.length];
   };
 
-  const getEvents = () => {
+  const getEvents = useCallback(() => {
     return schedules.map((schedule, index) => ({
       id: schedule.id,
       title: schedule.title,
@@ -59,9 +59,12 @@ const CalendarView: React.FC<CalendarViewProps> = ({
       end: schedule.endDate,
       backgroundColor: getBackgroundColor(schedule, index),
       borderColor: "transparent",
-      classNames: ["calendar-event"],
+      classNames: schedule.url
+        ? ["calendar-event", "cursor-pointer"]
+        : ["calendar-event", "cursor-default"],
+      extendedProps: { url: schedule.url },
     }));
-  };
+  }, [schedules]);
 
   useEffect(() => {
     const calendarApi = calendarRef.current?.getApi();
@@ -69,7 +72,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
       calendarApi.removeAllEvents();
       calendarApi.addEventSource(getEvents());
     }
-  }, [schedules]);
+  }, [getEvents]);
 
   const handlePrevMonth = () => {
     const calendarApi = calendarRef.current?.getApi();
@@ -123,6 +126,13 @@ const CalendarView: React.FC<CalendarViewProps> = ({
     );
   };
 
+  const handleEventClick = (clickInfo: EventClickArg) => {
+    const url = clickInfo.event.extendedProps.url;
+    if (url) {
+      window.open(url, "_blank");
+    }
+  };
+
   return (
     <div className="mt-4 overflow-hidden rounded-lg border border-gray-200">
       <CustomToolbar />
@@ -135,6 +145,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
           headerToolbar={false}
           events={getEvents()}
           eventContent={renderEventContent}
+          eventClick={handleEventClick}
           height="auto"
           firstDay={0}
           eventDisplay="block"

--- a/src/app/admin/(block)/calendar/components/calendar-view.tsx
+++ b/src/app/admin/(block)/calendar/components/calendar-view.tsx
@@ -1,52 +1,75 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { EventContentArg } from "@fullcalendar/core/index.js";
-
-interface Schedule {
-  id: string;
-  title: string;
-  startDate: string;
-  endDate: string;
-}
+import { Schedule } from "./types";
 
 interface CalendarViewProps {
   schedules: Schedule[];
+  hasUserSchedules: boolean;
 }
 
-const CalendarView: React.FC<CalendarViewProps> = ({ schedules }) => {
-  const [currentMonth, setCurrentMonth] = useState<Date>(new Date(2023, 0, 1));
+const CalendarView: React.FC<CalendarViewProps> = ({
+  schedules,
+  hasUserSchedules,
+}) => {
+  const initialDate = hasUserSchedules ? new Date() : new Date(2023, 0, 1);
+  const [currentMonth, setCurrentMonth] = useState<Date>(initialDate);
   const calendarRef = React.useRef<FullCalendar>(null);
 
-  const getBackgroundColor = (start: Date, end: Date) => {
-    const startDay = start.getDate();
-    const endDay = end.getDate();
+  const eventColors = [
+    "#575757",
+    "#707070",
+    "#888888",
+    "#A0A0A0",
+    "#666666",
+    "#999999",
+    "#777777",
+    "#949494",
+    "#555555",
+    "#808080",
+  ];
 
-    if (startDay >= 2 && endDay <= 6) {
-      return "#575757";
-    } else if (startDay >= 5 && endDay <= 10) {
-      return "#707070";
-    } else {
-      return "#A0A0A0";
+  const getBackgroundColor = (schedule: Schedule, index: number) => {
+    if (["1", "2", "3"].includes(String(schedule.id))) {
+      const startDay = new Date(schedule.startDate).getDate();
+      const endDay = new Date(schedule.endDate).getDate();
+
+      if (startDay >= 2 && endDay <= 6) {
+        return "#575757";
+      } else if (startDay >= 5 && endDay <= 10) {
+        return "#707070";
+      } else {
+        return "#A0A0A0";
+      }
     }
+
+    return eventColors[index % eventColors.length];
   };
 
-  const events = schedules.map((schedule) => ({
-    id: schedule.id,
-    title: schedule.title,
-    start: schedule.startDate,
-    end: schedule.endDate,
-    backgroundColor: getBackgroundColor(
-      new Date(schedule.startDate),
-      new Date(schedule.endDate),
-    ),
-    borderColor: "transparent",
-    classNames: ["calendar-event"],
-  }));
+  const getEvents = () => {
+    return schedules.map((schedule, index) => ({
+      id: schedule.id,
+      title: schedule.title,
+      start: schedule.startDate,
+      end: schedule.endDate,
+      backgroundColor: getBackgroundColor(schedule, index),
+      borderColor: "transparent",
+      classNames: ["calendar-event"],
+    }));
+  };
+
+  useEffect(() => {
+    const calendarApi = calendarRef.current?.getApi();
+    if (calendarApi) {
+      calendarApi.removeAllEvents();
+      calendarApi.addEventSource(getEvents());
+    }
+  }, [schedules]);
 
   const handlePrevMonth = () => {
     const calendarApi = calendarRef.current?.getApi();
@@ -104,14 +127,13 @@ const CalendarView: React.FC<CalendarViewProps> = ({ schedules }) => {
     <div className="mt-4 overflow-hidden rounded-lg border border-gray-200">
       <CustomToolbar />
       <div className="calendar-container [&_.calendar-event]:flex [&_.calendar-event]:h-8 [&_.calendar-event]:items-center [&_.fc-col-header-cell]:border-0 [&_.fc-col-header-cell]:border-b [&_.fc-col-header-cell]:border-gray-200 [&_.fc-col-header-cell]:py-2 [&_.fc-col-header-cell]:text-center [&_.fc-col-header-cell]:text-[11px] [&_.fc-col-header-cell]:font-medium [&_.fc-col-header-cell]:text-gray-500 [&_.fc-day-other_.fc-daygrid-day-number]:text-gray-400 [&_.fc-daygrid-day-number]:flex [&_.fc-daygrid-day-number]:h-8 [&_.fc-daygrid-day-number]:w-full [&_.fc-daygrid-day-number]:items-center [&_.fc-daygrid-day-number]:justify-center [&_.fc-daygrid-day-number]:text-[11px] [&_.fc-daygrid-event]:mx-1 [&_.fc-daygrid-event]:rounded-md [&_.fc-event-title]:overflow-hidden [&_.fc-scrollgrid-section>td]:!border-b-0 [&_.fc-scrollgrid-section>td]:!border-r-0 [&_.fc-scrollgrid-section>th]:!border-r-0 [&_.fc-scrollgrid]:border-0 [&_td]:!border-b-0 [&_td]:!border-r-0">
-        {" "}
         <FullCalendar
           ref={calendarRef}
           plugins={[dayGridPlugin, interactionPlugin]}
           initialView="dayGridMonth"
-          initialDate="2023-01-01"
+          initialDate={initialDate}
           headerToolbar={false}
-          events={events}
+          events={getEvents()}
           eventContent={renderEventContent}
           height="auto"
           firstDay={0}

--- a/src/app/admin/(block)/calendar/components/list-view.tsx
+++ b/src/app/admin/(block)/calendar/components/list-view.tsx
@@ -61,6 +61,12 @@ const getScheduleStatus = (schedule: Schedule, index: number) => {
 };
 
 const ListView: React.FC<ListViewProps> = ({ schedules }) => {
+  const handleClick = (url: string) => {
+    if (url) {
+      window.open(url, "_blank");
+    }
+  };
+
   return (
     <div className="relative mt-4 space-y-0 rounded-lg bg-white p-4 shadow">
       <div className="relative max-h-[400px] overflow-y-auto">
@@ -68,10 +74,14 @@ const ListView: React.FC<ListViewProps> = ({ schedules }) => {
           <div className="pr-4 [&::-webkit-scrollbar]:hidden">
             {schedules.map((schedule, index) => {
               const status = getScheduleStatus(schedule, index);
+              const hasUrl = Boolean(schedule.url);
               return (
                 <div
                   key={schedule.id}
-                  className="relative flex items-start pb-6"
+                  className={`relative flex items-start pb-6 ${
+                    hasUrl ? "cursor-pointer hover:text-[var(--primary)]" : ""
+                  }`}
+                  onClick={() => hasUrl && handleClick(schedule.url!)}
                 >
                   <div className="z-10 w-24 flex-shrink-0">
                     <span

--- a/src/app/admin/(block)/calendar/components/list-view.tsx
+++ b/src/app/admin/(block)/calendar/components/list-view.tsx
@@ -1,63 +1,107 @@
 import React from "react";
-
-interface Schedule {
-  id: string;
-  title: string;
-  startDate: string;
-  endDate: string;
-}
+import { Schedule } from "./types";
 
 interface ListViewProps {
   schedules: Schedule[];
 }
 
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hour = date.getHours();
+  const ampm = hour >= 12 ? "오후" : "오전";
+  const hour12 = hour % 12 || 12;
+  return `${month}.${day} (${ampm} ${hour12}시)`;
+};
+
+const getScheduleStatus = (schedule: Schedule, index: number) => {
+  if (["1", "2", "3"].includes(String(schedule.id))) {
+    if (index === 0) {
+      return {
+        text: "OPEN",
+        color: "bg-[var(--primary)] text-white",
+      };
+    } else if (index === 1) {
+      return {
+        text: "D-3",
+        color: "bg-gray-200 text-[var(--primary)]",
+      };
+    } else {
+      return {
+        text: "SOON",
+        color: "bg-gray-200 text-[var(--primary)]",
+      };
+    }
+  }
+
+  const startDate = new Date(schedule.startDate);
+  const endDate = new Date(schedule.endDate);
+  const now = new Date();
+
+  if (now < startDate) {
+    const diffDays = Math.ceil(
+      (startDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    return {
+      text: `D-${diffDays}`,
+      color: "bg-gray-200 text-[var(--primary)]",
+    };
+  } else if (now >= startDate && now <= endDate) {
+    return {
+      text: "OPEN",
+      color: "bg-[var(--primary)] text-white",
+    };
+  } else {
+    return {
+      text: "CLOSED",
+      color: "bg-[#BABABA] text-[#eae9e9]",
+    };
+  }
+};
+
 const ListView: React.FC<ListViewProps> = ({ schedules }) => {
   return (
     <div className="relative mt-4 space-y-0 rounded-lg bg-white p-4 shadow">
-      <div className="ml-10 mt-5">
-        <div
-          className="h-50 absolute bottom-4 left-[9.35rem] top-12 bg-gray-200"
-          style={{ width: "3px" }}
-        ></div>
-        {schedules.map((schedule, index) => (
-          <div key={schedule.id} className="relative flex items-start pb-6">
-            <div className="z-10 w-24 flex-shrink-0">
-              <span
-                className={`inline-block w-20 rounded-full px-3 py-1 text-center text-xs font-semibold ${index === 0 ? "bg-orange-500 text-white" : "bg-gray-200"}`}
-                style={index !== 0 ? { color: "var(--primary)" } : {}}
-              >
-                {index === 0 ? "OPEN" : index === 1 ? "D-3" : "SOON"}
-              </span>
-            </div>
-            <div className="relative ml-4">
-              <div className="absolute -left-[1.25rem] top-2 h-1.5 w-1.5 rounded-full bg-orange-500"></div>
-              <p className="mb-1 text-sm text-gray-500">
-                {new Date(schedule.startDate).toLocaleString("ko-KR", {
-                  month: "2-digit",
-                  day: "2-digit",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}{" "}
-                ~
-                {new Date(schedule.endDate).toLocaleString("ko-KR", {
-                  month: "2-digit",
-                  day: "2-digit",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
-              </p>
-              <p
-                className="text-sm font-semibold"
-                style={{
-                  textDecoration: "underline",
-                  textUnderlineOffset: "3px",
-                }}
-              >
-                {schedule.title}
-              </p>
-            </div>
+      <div className="relative max-h-[400px] overflow-y-auto">
+        <div className="ml-10 mt-5">
+          <div className="pr-4 [&::-webkit-scrollbar]:hidden">
+            {schedules.map((schedule, index) => {
+              const status = getScheduleStatus(schedule, index);
+              return (
+                <div
+                  key={schedule.id}
+                  className="relative flex items-start pb-6"
+                >
+                  <div className="z-10 w-24 flex-shrink-0">
+                    <span
+                      className={`inline-block w-20 rounded-full px-3 py-1 text-center text-xs font-semibold ${status.color}`}
+                    >
+                      {status.text}
+                    </span>
+                  </div>
+                  <div className="relative ml-4 flex-grow">
+                    <div className="absolute -left-[1.2rem] top-[0.8rem] h-16 w-1 bg-gray-200"></div>
+                    <div className="absolute -left-[1.25rem] top-2 h-1.5 w-1.5 rounded-full bg-orange-500"></div>
+                    <p className="mb-1 text-sm text-gray-500">
+                      {formatDate(schedule.startDate)} ~{" "}
+                      {formatDate(schedule.endDate)}
+                    </p>
+                    <p
+                      className="text-sm font-semibold"
+                      style={{
+                        textDecoration: "underline",
+                        textUnderlineOffset: "3px",
+                      }}
+                    >
+                      {schedule.title}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
           </div>
-        ))}
+        </div>
       </div>
     </div>
   );

--- a/src/app/admin/(block)/calendar/components/schedule-list.tsx
+++ b/src/app/admin/(block)/calendar/components/schedule-list.tsx
@@ -234,6 +234,8 @@ export default function ScheduleList() {
       if (responseData.code === 200) {
         setSchedules(updatedSchedules);
         alert("일정이 성공적으로 삭제되었습니다.");
+
+        window.location.reload();
       } else {
         throw new Error(
           `Failed to delete schedule. Server response: ${JSON.stringify(responseData)}`,

--- a/src/app/admin/(block)/calendar/components/style-setting.tsx
+++ b/src/app/admin/(block)/calendar/components/style-setting.tsx
@@ -1,11 +1,28 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import CalendarView from "./calendar-view";
 import ListView from "./list-view";
+import { Schedule } from "./types";
 
-const sampleSchedules = [
+interface ApiSchedule {
+  id: number;
+  title: string;
+  dateStart: string;
+  dateEnd: string;
+  url?: string;
+}
+
+interface CalendarBlock {
+  id: number;
+  type: number;
+  sequence: number;
+  style: number;
+  schedule: ApiSchedule[];
+}
+
+const sampleSchedules: Schedule[] = [
   {
     id: "1",
     title: "[SAMPLE] 첫 번째 일정 예시",
@@ -29,8 +46,67 @@ const sampleSchedules = [
 export default function StyleSetting() {
   const [isOpen, setIsOpen] = useState(true);
   const [activeView, setActiveView] = useState<"list" | "calendar">("list");
+  const [schedules, setSchedules] = useState<Schedule[]>([]);
+  const [calendarBlock, setCalendarBlock] = useState<CalendarBlock | null>(
+    null,
+  );
+  const [hasUserSchedules, setHasUserSchedules] = useState(false);
+
+  const fetchSchedules = async () => {
+    try {
+      const token = sessionStorage.getItem("token");
+      if (!token) {
+        throw new Error("로그인이 필요합니다.");
+      }
+
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/link/list`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      if (data.code === 200 && Array.isArray(data.data)) {
+        const foundCalendarBlock = data.data.find(
+          (item: CalendarBlock) => item.type === 7,
+        );
+
+        if (foundCalendarBlock && Array.isArray(foundCalendarBlock.schedule)) {
+          setCalendarBlock(foundCalendarBlock);
+          const formattedSchedules: Schedule[] =
+            foundCalendarBlock.schedule.map(
+              (schedule: ApiSchedule): Schedule => ({
+                id: String(schedule.id),
+                title: schedule.title,
+                startDate: schedule.dateStart,
+                endDate: schedule.dateEnd,
+                url: schedule.url,
+              }),
+            );
+          setSchedules(formattedSchedules);
+          setHasUserSchedules(formattedSchedules.length > 0);
+        }
+      }
+    } catch (err) {
+      console.error("Error fetching schedules:", err);
+    }
+  };
+
+  useEffect(() => {
+    fetchSchedules();
+  }, []);
 
   const toggleOpen = () => setIsOpen(!isOpen);
+
+  const currentSchedules = hasUserSchedules ? schedules : sampleSchedules;
 
   return (
     <div className="flex w-full max-w-4xl flex-col px-14 py-0">
@@ -51,30 +127,35 @@ export default function StyleSetting() {
       </div>
       {isOpen && (
         <div className="p-4">
-          <div className="mb-4 flex space-x-8">
-            <label className="flex items-center">
-              <input
-                type="radio"
-                checked={activeView === "list"}
-                onChange={() => setActiveView("list")}
-                className="form-radio h-5 w-5 border-gray-300 text-gray-400 focus:ring-gray-400"
-              />
-              <span className="ml-2 text-gray-400">리스트뷰</span>
-            </label>
-            <label className="flex items-center">
-              <input
-                type="radio"
-                checked={activeView === "calendar"}
-                onChange={() => setActiveView("calendar")}
-                className="form-radio h-5 w-5 border-gray-300 text-orange-500 focus:ring-orange-500"
-              />
-              <span className="ml-2 text-gray-400">캘린더뷰</span>
-            </label>
+          <div className="mb-4 flex items-center justify-between">
+            <div className="flex space-x-8">
+              <label className="flex items-center">
+                <input
+                  type="radio"
+                  checked={activeView === "list"}
+                  onChange={() => setActiveView("list")}
+                  className="form-radio h-5 w-5 border-gray-300 text-gray-400 focus:ring-gray-400"
+                />
+                <span className="ml-2 text-gray-400">리스트뷰</span>
+              </label>
+              <label className="flex items-center">
+                <input
+                  type="radio"
+                  checked={activeView === "calendar"}
+                  onChange={() => setActiveView("calendar")}
+                  className="form-radio h-5 w-5 border-gray-300 text-orange-500 focus:ring-orange-500"
+                />
+                <span className="ml-2 text-gray-400">캘린더뷰</span>
+              </label>
+            </div>
           </div>
           {activeView === "list" ? (
-            <ListView schedules={sampleSchedules} />
+            <ListView schedules={currentSchedules} />
           ) : (
-            <CalendarView schedules={sampleSchedules} />
+            <CalendarView
+              schedules={currentSchedules}
+              hasUserSchedules={hasUserSchedules}
+            />
           )}
         </div>
       )}

--- a/src/app/admin/(block)/calendar/components/types.ts
+++ b/src/app/admin/(block)/calendar/components/types.ts
@@ -1,0 +1,7 @@
+export interface Schedule {
+  id: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  url?: string;
+}


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->

## 작업사항

<!-- 작업한 내용 작성 -->

- 사용자의 일정이 없을 때 예시 데이터를 캘린더 블록에 표시
- 리스트 뷰에 사용자 일정 표시
- 캘린더 뷰에 사용자 일정 표시
- 일정에 마우스 hover 시 커서가 손 모양으로 변경되고, 클릭 시 URL 이동 기능 구현

## 미리보기, 사용방법 및 결과물

<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
- 일정이 없는 경우
  - 사용자의 일정이 없으면 캘린더 블록에 기본 예시 일정이 표시된다.
- 일정 추가 시
  - 일정이 추가되면 리스트뷰와 캘린더뷰에 자동으로 반영된다.
- 인터랙션
  - 캘린더나 리스트에서 일정 항목에 마우스를 올리면 커서가 손 모양으로 변경되며, 클릭 시 해당 일정과 연결된 URL로 이동된다.

![스크린샷 2024-10-23 194343](https://github.com/user-attachments/assets/d88d23ee-2fba-4f98-8408-8d89d597f710) 
![image](https://github.com/user-attachments/assets/2d222ea7-3d8b-4fee-a438-ced47b09d7b8)
![image](https://github.com/user-attachments/assets/14da5ff9-32ef-4f7d-8b79-71c1768c4929)

## 기타

<!-- 필요한 경우 작성 -->

## 작성일

<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->

2024.10.23
