### PR TITLE
🎨[Style] eslint plugin import 을 통한 프로젝트 파일 일괄 import 문 정리 #243

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "plugins": ["prettier", "import"],
   "rules": {
     "prettier/prettier": ["error"],
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/no-explicit-any": "off",
     "react/react-in-jsx-scope": "off",
     "import/order": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "plugins": ["prettier", "import"],
   "rules": {
     "prettier/prettier": ["error"],
-    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "off",
     "react/react-in-jsx-scope": "off",
     "import/order": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,15 +7,15 @@
     "@typescript-eslint/no-explicit-any": "off",
     "react/react-in-jsx-scope": "off",
     "import/order": [
-      "error",
+      "warn",
       {
         "groups": [
           "builtin",
           "external",
           "internal",
-          "parent",
-          "sibling",
-          "index"
+          ["sibling", "parent"],
+          "index",
+          "object"
         ],
         "newlines-between": "always"
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,24 @@
 {
   "extends": ["next/core-web-vitals", "next/typescript", "prettier"],
-  "plugins": ["prettier"],
+  "plugins": ["prettier", "import"],
   "rules": {
     "prettier/prettier": ["error"],
     "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/no-explicit-any": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index"
+        ],
+        "newlines-between": "always"
+      }
+    ]
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": "always",
-    "source.fixAll.eslint": "always"
-  },
   "typescript.tsdk": "node_modules/typescript/lib",
   // tailwind
   // "tailwind-fold.unfoldedTextOpacity": 1,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "always",
+    "source.fixAll.eslint": "always"
+  },
   "typescript.tsdk": "node_modules/typescript/lib",
   // tailwind
   // "tailwind-fold.unfoldedTextOpacity": 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint": "^8",
         "eslint-config-next": "14.2.14",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-prettier": "^5.2.1",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.14",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.2.1",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",

--- a/src/app/admin/(block)/block-menu.tsx
+++ b/src/app/admin/(block)/block-menu.tsx
@@ -1,10 +1,11 @@
 import React, { SetStateAction } from "react";
-import { blockTypes } from "@/types/block_types";
 import Link from "next/link";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
+
+import { blockTypes } from "@/types/block_types";
 import Portal from "@app/components/portal";
 import Contour from "@app/admin/(block)/components/contour";
-import { usePathname } from "next/navigation";
 
 interface Props {
   isOpen: boolean;

--- a/src/app/admin/(block)/calendar/components/calendar-view.tsx
+++ b/src/app/admin/(block)/calendar/components/calendar-view.tsx
@@ -6,6 +6,7 @@ import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { EventContentArg } from "@fullcalendar/core";
+
 import { Schedule } from "./types";
 
 interface CalendarViewProps {

--- a/src/app/admin/(block)/calendar/components/list-view.tsx
+++ b/src/app/admin/(block)/calendar/components/list-view.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Schedule } from "./types";
 
 interface ListViewProps {

--- a/src/app/admin/(block)/calendar/components/schedule-form.tsx
+++ b/src/app/admin/(block)/calendar/components/schedule-form.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+
 import AddButton from "../../components/buttons/add-button";
 import ButtonBox from "../../components/buttons/button-box";
 import FormInput from "../../components/form-input";

--- a/src/app/admin/(block)/calendar/components/style-setting.tsx
+++ b/src/app/admin/(block)/calendar/components/style-setting.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
+
 import CalendarView from "./calendar-view";
 import ListView from "./list-view";
 import { Schedule } from "./types";

--- a/src/app/admin/(block)/calendar/manage/page.tsx
+++ b/src/app/admin/(block)/calendar/manage/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
+
 import ScheduleForm from "../components/schedule-form";
 
 interface Schedule {

--- a/src/app/admin/(block)/calendar/page.tsx
+++ b/src/app/admin/(block)/calendar/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
+import React, { Suspense } from "react";
+
 import Layout from "../components/layout";
 import CalendarHeader from "./components/calendar-header";
 import ScheduleList from "./components/schedule-list";
 import StyleSetting from "./components/style-setting";
-import React, { Suspense } from "react";
 
 function CalendarPage() {
   const prevPath = useSearchParams().get("prevPath") || "/admin";

--- a/src/app/admin/(block)/components/layout.tsx
+++ b/src/app/admin/(block)/components/layout.tsx
@@ -1,7 +1,8 @@
 import React, { FormEvent, Suspense } from "react";
 import Image from "next/image";
-import QuestionIcon from "@app/admin/(block)/components/question-icon";
 import Link from "next/link";
+
+import QuestionIcon from "@app/admin/(block)/components/question-icon";
 
 const Layout = ({
   title,

--- a/src/app/admin/(block)/divider/components/divider-preview.tsx
+++ b/src/app/admin/(block)/divider/components/divider-preview.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Image from "next/image";
+
 import { DividerType } from "../../divider/types";
 
 interface DividerPreviewProps {

--- a/src/app/admin/(block)/divider/components/divider-selector.tsx
+++ b/src/app/admin/(block)/divider/components/divider-selector.tsx
@@ -1,5 +1,6 @@
-import { Divider, DividerType } from "../types";
 import Image from "next/image";
+
+import { Divider, DividerType } from "../types";
 
 interface DividerSelectorProps {
   onSelect: (divider: DividerType) => void;

--- a/src/app/admin/(block)/divider/page.tsx
+++ b/src/app/admin/(block)/divider/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import React, { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import ButtonBox from "@app/admin/(block)/components/buttons/button-box";
+import AddButton from "@app/admin/(block)/components/buttons/add-button";
+import { adminApiInstance } from "utils/apis";
+
 import Layout from "../components/layout";
 import DividerPreview from "./components/divider-preview";
 import DividerSelector from "./components/divider-selector";
 import { DividerType } from "./types";
-import ButtonBox from "@app/admin/(block)/components/buttons/button-box";
-import AddButton from "@app/admin/(block)/components/buttons/add-button";
-import { adminApiInstance } from "utils/apis";
-import { useRouter, useSearchParams } from "next/navigation";
 
 function DividerPage() {
   const router = useRouter();

--- a/src/app/admin/(block)/event/components/event-form.tsx
+++ b/src/app/admin/(block)/event/components/event-form.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { FormEvent, useState } from "react";
-import EventDatePicker from "./event-date-picker";
-import EventPreview from "./event-preview";
+import { useRouter, useSearchParams } from "next/navigation";
+
 import Layout from "../../components/layout";
+import EventPreview from "./event-preview";
 import ButtonBox from "../../components/buttons/button-box";
 import AddButton from "../../components/buttons/add-button";
 import FormInput from "../../components/form-input";
-import { useRouter, useSearchParams } from "next/navigation";
+
 import "react-datepicker/dist/react-datepicker.css";
 import { adminApiInstance } from "../../../../../utils/apis";
+import EventDatePicker from "./event-date-picker";
 
 export default function EventForm() {
   const [title, setTitle] = useState("");

--- a/src/app/admin/(block)/event/page.tsx
+++ b/src/app/admin/(block)/event/page.tsx
@@ -1,5 +1,6 @@
-import EventForm from "./components/event-form";
 import React, { Suspense } from "react";
+
+import EventForm from "./components/event-form";
 
 function Page() {
   return <EventForm />;

--- a/src/app/admin/(block)/image/components/image-box.tsx
+++ b/src/app/admin/(block)/image/components/image-box.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import Image from "next/image";
-import ErrorBoundary from "@app/intro/components/error-boundary";
 import Link from "next/link";
+
+import ErrorBoundary from "@app/intro/components/error-boundary";
 
 interface Props {
   // handeInputImageClick: () => void;

--- a/src/app/admin/(block)/image/page.tsx
+++ b/src/app/admin/(block)/image/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 import React, { FormEvent, Suspense, useState } from "react";
-import Layout from "@app/admin/(block)/components/layout";
+import { useRouter, useSearchParams } from "next/navigation";
 
+import Layout from "@app/admin/(block)/components/layout";
 import AddButton from "@app/admin/(block)/components/buttons/add-button";
 import ButtonBox from "@app/admin/(block)/components/buttons/button-box";
 import ImageBox from "@app/admin/(block)/image/components/image-box";
-import { useRouter, useSearchParams } from "next/navigation";
 import FormInput from "@app/admin/(block)/components/form-input";
+
 import { checkUrl } from "../../../../lib/check-url";
 import { adminApiInstance } from "../../../../utils/apis";
 

--- a/src/app/admin/(block)/link/components/link-form.tsx
+++ b/src/app/admin/(block)/link/components/link-form.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import AddButton from "@app/admin/(block)/components/buttons/add-button";
-import ButtonBox from "@app/admin/(block)/components/buttons/button-box";
-import Layout from "@app/admin/(block)/components/layout";
-import { checkUrl } from "lib/check-url";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   ChangeEvent,
@@ -12,6 +8,12 @@ import {
   useEffect,
   useState,
 } from "react";
+
+import AddButton from "@app/admin/(block)/components/buttons/add-button";
+import ButtonBox from "@app/admin/(block)/components/buttons/button-box";
+import Layout from "@app/admin/(block)/components/layout";
+import { checkUrl } from "lib/check-url";
+
 import { adminApiInstance } from "../../../../../utils/apis";
 import FormInput from "../../components/form-input";
 import StylePreview from "./style-preview";

--- a/src/app/admin/(block)/link/page.tsx
+++ b/src/app/admin/(block)/link/page.tsx
@@ -1,5 +1,6 @@
-import LinkForm from "./components/link-form";
 import React, { Suspense } from "react";
+
+import LinkForm from "./components/link-form";
 
 function LinkPage() {
   return <LinkForm />;

--- a/src/app/admin/(block)/paint/page.tsx
+++ b/src/app/admin/(block)/paint/page.tsx
@@ -6,9 +6,10 @@ import React, {
   useRef,
   useState,
 } from "react";
+import * as fabric from "fabric";
+
 import Layout from "@app/admin/(block)/components/layout";
 // import { useSearchParams } from "next/navigation";
-import * as fabric from "fabric";
 
 const Page = () => {
   const [canvas, setCanvas] = useState<fabric.Canvas | null>();

--- a/src/app/admin/(block)/text/page.tsx
+++ b/src/app/admin/(block)/text/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
+import React, { Suspense, useState } from "react";
+
 import Layout from "../components/layout";
 import FormInput from "../components/form-input";
 import ButtonBox from "../components/buttons/button-box";
 import AddButton from "../components/buttons/add-button";
-import React, { Suspense, useState } from "react";
 import { adminApiInstance } from "../../../../utils/apis";
 
 function TextPage() {

--- a/src/app/admin/(block)/video/page.tsx
+++ b/src/app/admin/(block)/video/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import React, { FormEvent, Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
 import Layout from "@app/admin/(block)/components/layout";
 import AddButton from "@app/admin/(block)/components/buttons/add-button";
 import ButtonBox from "@app/admin/(block)/components/buttons/button-box";
-import { useRouter, useSearchParams } from "next/navigation";
 import FormInput from "@app/admin/(block)/components/form-input";
+
 import { checkImage, checkUrl } from "../../../../lib/check-url";
 import { adminApiInstance } from "../../../../utils/apis";
 

--- a/src/app/admin/components/home-menu.tsx
+++ b/src/app/admin/components/home-menu.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { ClientRoute } from "@config/route";
 import { useRouter } from "next/navigation";
+
+import { ClientRoute } from "@config/route";
 import Contour from "@app/admin/(block)/components/contour";
 
 const HomeMenu = () => {

--- a/src/app/admin/components/link-block.tsx
+++ b/src/app/admin/components/link-block.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+
 import TypeOne from "./link-block-sub/type-one";
 import TypeTwo from "./link-block-sub/type-two";
 import TypeThree from "./link-block-sub/type-three";

--- a/src/app/admin/components/preview/components/preview-calendar.tsx
+++ b/src/app/admin/components/preview/components/preview-calendar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Block } from "@app/admin/page";
 import { ScheduleItem } from "@app/admin/(block)/calendar/components/schedule-list";
 

--- a/src/app/admin/components/preview/components/preview-divider.tsx
+++ b/src/app/admin/components/preview/components/preview-divider.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+
 import { Block } from "@app/admin/page";
 import { DividerType } from "@app/admin/(block)/divider/types";
 import { DividerContent } from "@app/admin/(block)/divider/components/divider-preview";

--- a/src/app/admin/components/preview/components/preview-event.tsx
+++ b/src/app/admin/components/preview/components/preview-event.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Block } from "@app/admin/page";
 import EventPreview from "@app/admin/(block)/event/components/event-preview";
 

--- a/src/app/admin/components/preview/components/preview-image.tsx
+++ b/src/app/admin/components/preview/components/preview-image.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Block } from "@app/admin/page";
 import ImageBox from "@app/admin/(block)/image/components/image-box";
 

--- a/src/app/admin/components/preview/components/preview-link.tsx
+++ b/src/app/admin/components/preview/components/preview-link.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Block } from "@app/admin/page";
 import { usePathname } from "next/navigation";
+
+import { Block } from "@app/admin/page";
 import StylePreview from "@app/admin/(block)/link/components/style-preview";
 
 interface Props {

--- a/src/app/admin/components/preview/components/preview-link.tsx
+++ b/src/app/admin/components/preview/components/preview-link.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 import { usePathname } from "next/navigation";
 
 import { Block } from "@app/admin/page";
-import { Block } from "@app/admin/page";
 import StylePreview from "@app/admin/(block)/link/components/style-preview";
 
 import { checkUrl } from "../../../../../lib/check-url";

--- a/src/app/admin/components/preview/components/preview-text.tsx
+++ b/src/app/admin/components/preview/components/preview-text.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Block } from "@app/admin/page";
 import { twMerge } from "tailwind-merge";
+
+import { Block } from "@app/admin/page";
 
 interface Props {
   block: Block;

--- a/src/app/admin/components/preview/components/preview-video.tsx
+++ b/src/app/admin/components/preview/components/preview-video.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { Block } from "@app/admin/page";
 import { twMerge } from "tailwind-merge";
 import { usePathname } from "next/navigation";
+
+import { Block } from "@app/admin/page";
 
 interface Props {
   block: Block;

--- a/src/app/admin/components/preview/components/preview.tsx
+++ b/src/app/admin/components/preview/components/preview.tsx
@@ -1,6 +1,6 @@
 import React, { SetStateAction } from "react";
-import ProfileBox from "@app/admin/components/profile-box";
 
+import ProfileBox from "@app/admin/components/profile-box";
 import BlockList from "@app/components/page/block-list";
 
 interface Props {

--- a/src/app/admin/components/preview/preview-modal.tsx
+++ b/src/app/admin/components/preview/preview-modal.tsx
@@ -1,4 +1,5 @@
 import React, { SetStateAction } from "react";
+
 import Portal from "@app/components/portal";
 import { Block } from "@app/admin/page";
 import Preview from "@app/admin/components/preview/components/preview";

--- a/src/app/admin/components/profile-box.tsx
+++ b/src/app/admin/components/profile-box.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { twMerge } from "tailwind-merge";
-import HomeMenu from "@app/admin/components/home-menu";
 import Link from "next/link";
-import { ClientRoute } from "@config/route";
 import Image from "next/image";
-import { useTheme } from "@components/providers/theme-provider";
 import { usePathname } from "next/navigation";
+
+import HomeMenu from "@app/admin/components/home-menu";
+import { ClientRoute } from "@config/route";
+import { useTheme } from "@components/providers/theme-provider";
 
 const ProfileBox = () => {
   const { theme } = useTheme();

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import BlockMenu from "@app/admin/(block)/block-menu";
-import BasicBlock from "@app/intro/components/basicblock";
-import EmptyBlock from "@app/intro/components/UI/empty-block";
-
-import CircleButton from "@app/admin/components/buttons/circle-button";
-import PreviewModal from "@app/admin/components/preview/preview-modal";
-import ProfileBox from "@app/admin/components/profile-box";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+
+import BlockMenu from "@app/admin/(block)/block-menu";
+import BasicBlock from "@app/intro/components/basicblock";
+import EmptyBlock from "@app/intro/components/UI/empty-block";
+import CircleButton from "@app/admin/components/buttons/circle-button";
+import PreviewModal from "@app/admin/components/preview/preview-modal";
+import ProfileBox from "@app/admin/components/profile-box";
+
 import { adminApiInstance } from "../../utils/apis";
 
 export interface Block {

--- a/src/app/api/link/add/route.tsx
+++ b/src/app/api/link/add/route.tsx
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import jwt from "jsonwebtoken";
+
 import clientPromise from "../../../../lib/mongodb";
 
 interface JwtPayload {

--- a/src/app/api/link/delete/route.tsx
+++ b/src/app/api/link/delete/route.tsx
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import jwt from "jsonwebtoken";
-import clientPromise from "../../../../lib/mongodb";
 import { Collection } from "mongodb";
+
+import clientPromise from "../../../../lib/mongodb";
 
 interface JwtPayload {
   userId: string;

--- a/src/app/api/link/list/route.tsx
+++ b/src/app/api/link/list/route.tsx
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import jwt from "jsonwebtoken";
+
 import clientPromise from "../../../../lib/mongodb";
 
 interface JwtPayload {

--- a/src/app/api/link/update/route.tsx
+++ b/src/app/api/link/update/route.tsx
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import jwt from "jsonwebtoken";
-import clientPromise from "../../../../lib/mongodb";
 import { Collection } from "mongodb";
+
+import clientPromise from "../../../../lib/mongodb";
 
 interface JwtPayload {
   userId: string;

--- a/src/app/api/login/route.tsx
+++ b/src/app/api/login/route.tsx
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
-import clientPromise from "../../../lib/mongodb";
 import jwt from "jsonwebtoken";
 import type { NextRequest } from "next/server";
 import type { MongoClient, Db, Collection } from "mongodb";
+
+import clientPromise from "../../../lib/mongodb";
 
 interface User {
   userId: string;

--- a/src/app/api/user/add/route.tsx
+++ b/src/app/api/user/add/route.tsx
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
+
 import clientPromise from "../../../../lib/mongodb";
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/user/delete/route.tsx
+++ b/src/app/api/user/delete/route.tsx
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import jwt from "jsonwebtoken";
+
 import clientPromise from "../../../../lib/mongodb";
 
 interface JwtPayload {

--- a/src/app/api/user/info/route.tsx
+++ b/src/app/api/user/info/route.tsx
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import jwt from "jsonwebtoken";
+
 import clientPromise from "../../../../lib/mongodb";
 
 interface JwtPayload {

--- a/src/app/api/user/update/route.tsx
+++ b/src/app/api/user/update/route.tsx
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import jwt from "jsonwebtoken";
+
 import clientPromise from "../../../../lib/mongodb";
 
 interface JwtPayload {

--- a/src/app/components/page/block-list.tsx
+++ b/src/app/components/page/block-list.tsx
@@ -1,11 +1,13 @@
 import React, { Suspense, useEffect, useState } from "react";
-import { Block } from "@app/admin/page";
 import dynamic from "next/dynamic";
+import { usePathname } from "next/navigation";
+
+import { Block } from "@app/admin/page";
 import PreviewLink from "@app/admin/components/preview/components/preview-link";
 import PreviewText from "@app/admin/components/preview/components/preview-text";
 import CircleButton from "@app/admin/components/buttons/circle-button";
 import EmptyBlock from "@app/intro/components/UI/empty-block";
-import { usePathname } from "next/navigation";
+
 import { adminApiInstance } from "../../../utils/apis";
 const PreviewImage = dynamic(
   () => import("@app/admin/components/preview/components/preview-image"),

--- a/src/app/intro/components/basicblock.tsx
+++ b/src/app/intro/components/basicblock.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import ToggleButton from "./UI/toggle-button";
 import { useState } from "react";
+
 import DivideBlock from "@app/admin/components/divide-block";
 import VideoBlock from "@app/admin/components/video-block";
 import LinkBlock from "@app/admin/components/link-block";
@@ -10,6 +10,8 @@ import ImageBlock from "@app/admin/components/image-block";
 import EventBlock from "@app/admin/components/event-block";
 import TextBlock from "@app/admin/components/text-block";
 import CalendarBlock from "@app/admin/components/calendar-block";
+
+import ToggleButton from "./UI/toggle-button";
 
 interface Block {
   id: number;

--- a/src/app/intro/page.tsx
+++ b/src/app/intro/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+
 import { ClientRoute } from "@config/route";
 
 export default function Intro() {

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import FormInput from "@app/admin/(block)/components/form-input";
-import { ClientRoute } from "@config/route";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { twMerge } from "tailwind-merge";
+
+import { ClientRoute } from "@config/route";
+import FormInput from "@app/admin/(block)/components/form-input";
 import AnimatedText from "@components/common/ui/animated-text";
 
 export default function Join() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+
 import { ThemeProvider } from "@components/providers/theme-provider";
 import { ThemeToggle } from "@components/common/ui/theme-toggle";
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import FormInput from "@app/admin/(block)/components/form-input";
-import { ClientRoute } from "@config/route";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { twMerge } from "tailwind-merge";
+
+import { ClientRoute } from "@config/route";
+import FormInput from "@app/admin/(block)/components/form-input";
+
 import { authApiInstance } from "../../utils/apis";
 
 export default function Login() {

--- a/src/app/profile/detail/page.tsx
+++ b/src/app/profile/detail/page.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { User } from "@/types/user";
-import FormInput from "@app/admin/(block)/components/form-input";
 import Image from "next/image";
 import { twMerge } from "tailwind-merge";
+
+import { User } from "@/types/user";
+import FormInput from "@app/admin/(block)/components/form-input";
 
 export default function ProfileDetail() {
   const [userData, setUserData] = useState<User | null>(null);

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -2,10 +2,11 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useCallback } from "react";
-import { User } from "@/types/user";
-import FormInput from "@app/admin/(block)/components/form-input";
 import Image from "next/image";
 import { twMerge } from "tailwind-merge";
+
+import { User } from "@/types/user";
+import FormInput from "@app/admin/(block)/components/form-input";
 import AnimatedText from "@components/common/ui/animated-text";
 
 type FormErrors = {

--- a/src/components/common/ui/theme-toggle.tsx
+++ b/src/components/common/ui/theme-toggle.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useTheme } from "@components/providers/theme-provider";
 import { CiLight, CiDark } from "react-icons/ci";
+
+import { useTheme } from "@components/providers/theme-provider";
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();

--- a/src/types/block_types.ts
+++ b/src/types/block_types.ts
@@ -1,4 +1,5 @@
 import { StaticImageData } from "next/image";
+
 import {
   CALENDAR_ICON,
   DIVIDE_ICON,

--- a/src/utils/with-login.tsx
+++ b/src/utils/with-login.tsx
@@ -1,7 +1,10 @@
 import React, { ComponentType } from "react";
 import { JSX } from "react/jsx-runtime";
+
 import IntrinsicAttributes = JSX.IntrinsicAttributes;
+
 import Link from "next/link";
+
 import Intro from "@app/intro/page";
 
 // 로그인 상태에 따라 컴포넌트를 렌더링


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
:emoji:[태그] 제목 #이슈번호
태그 첫 글자는 대문자로 작성
예시) ✨[Feat] 로그인 기능 구현 #32

* 제목 태그 종류
✨[Feat] 새로운 기능 추가
🐛[Fix] 버그 수정
📝[Docs] 문서 수정
🎨[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
💄[Design] CSS 등 사용자 UI 디자인 변경
♻️[Refactor] 코드 리팩토링
✅[Test] 테스트 코드, 리팩토링 테스트 코드 추가
📦[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->

## 작업사항
<!-- 작업한 내용 작성 -->
- eslint plugin import을 통한 프로젝트 각 파일 상단 import 문들 정렬 및 정리
  - `eslint-plugin-import` 설치
  - `.eslintrc.json` 파일 내부의 설정을 구축
  - `npm run fix` 명령어를 통한 테스트 및 파일들의 import 문 정렬 적용

## 미리보기, 사용방법 및 결과물
<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
### 정렬 관련 설정 코드
![image](https://github.com/user-attachments/assets/e1b1c92b-033e-453f-94f0-d3dabce8f20b)
- 각 파일에서 필요한 import문 작성 후 `npm run fix` 명령어 입력 시, 설정된 코드에 맞춰 자동 정렬
- vsc 자체 기능인 `organize import`와는 정렬 기준이 다름.
- eslint 설정 파일의 기준을 따르는 `npm run fix`를 이용하길 추천

## 기타
<!-- 필요한 경우 작성 -->
- vsc 편집기에서 제공하는 `organize import` 와 같이 import 이후 미사용 요소들에 대한 삭제 또한 구현하려 했으나, 이는 불가능한것으로 확인
  - import 문 하단 코드 본문에서의 미사용 변수에 또한 같은 규칙이 적용되며, 이 부분에 대해서는 직접 수정이 필요함으로.
  - 이후 코드 정리 단계에서 콘솔 출력 및 주석들의 정리 과정에서 미사용 변수에 대한 정리와 더불어 import 이후 사용하지 않은 요소 또한 각자 정리해야 할 것으로 생각.

## 작성일

<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->

2024.11.15
